### PR TITLE
[codex] 新增 loopforge 工作流循环技能

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Smith Skills
 
-自用/精选的 Claude Code / Codex Skills 仓库，包含 n8n 工作流迁移、自研调研与内容工具、Grok X 实时抓取、Claude headless review 等。
+自用/精选的 Claude Code / Codex Skills 仓库，包含 n8n 工作流迁移、自研调研与内容工具、Agent workflow loop 设计、Grok X 实时抓取、Claude headless review 等。
 
 ## Skills 列表
 
@@ -39,6 +39,7 @@
 | Skill | 描述 |
 |-------|------|
 | [skill_auditor](./skill_auditor/) | Claude Skills 安全审计工具 |
+| [loopforge](./loopforge/) | 把模糊工作流锻造成可维护的 AI-agent workflow loop：同时输出 `loop-spec-v1` YAML/JSON 和可复制 Loop Prompt |
 | [claude-review](./claude-review/) | Codex 驱动 Claude 做 headless 评审（plan / 架构 / 文档 / work-log），自动链式调用 `plan-eng-review`。安装到 `~/.codex/skills/` |
 | [grok](./grok/) | 让 Claude 调本地 Grok Build CLI 抓 X (Twitter) 实时 firehose 内容（带 @用户名/互动数/链接的真实帖子）。复用 grok.com 订阅零额外成本。三模式：x 实时抓取 / ask 第二意见 / continue 续接 |
 
@@ -63,6 +64,7 @@ cp -r <skill-name> ~/.claude/skills/
 - "生成一个LinkedIn帖子"
 - "检查这个网站的SEO"
 - "用 STORM 调研这个选题是否值得写"
+- "用 loopforge 把这个工作流变成可复用 loop spec 和提示词"
 - 为来实现和n8n的工作节点相同,有些skill绕路远路,建议可以依据需要修改
 
 ## 依赖的 MCP 服务

--- a/README.md
+++ b/README.md
@@ -1,39 +1,39 @@
 # Smith Skills
 
-自用/精选的 Claude Code / Codex Skills 仓库，包含 n8n 工作流迁移、自研调研与内容工具、Agent workflow loop 设计、Grok X 实时抓取、Claude headless review 等。
+自用/精选的 Claude Code / Codex Skills 仓库，覆盖内容创作、客户服务、市场调研、SEO 优化、Agent workflow loop 设计、Grok X 实时抓取、Claude headless review 等场景。
 
 ## Skills 列表
 
 ### 营销与内容创作
-| Skill | 描述 | 原始模板 |
-|-------|------|---------|
-| [video-creator](./video-creator/) | AI视频创作（jimeng MCP + Playwright） | [#10358](https://n8n.io/workflows/10358) |
-| [viral-post-creator](./viral-post-creator/) | 病毒式社交帖子生成器 | [#8756](https://n8n.io/workflows/8756) |
-| [linkedin-post-creator](./linkedin-post-creator/) | LinkedIn帖子创作 | [#6979](https://n8n.io/workflows/6979) |
-| [cold-email-personalizer](./cold-email-personalizer/) | 冷邮件个性化 | [#6089](https://n8n.io/workflows/6089) |
+| Skill | 描述 |
+|-------|------|
+| [video-creator](./video-creator/) | AI 视频创作：生成脚本、调用视频/浏览器工具、整理发布报告 |
+| [viral-post-creator](./viral-post-creator/) | 病毒式社交帖子生成：从主题生成文案、配图方向和平台发布建议 |
+| [linkedin-post-creator](./linkedin-post-creator/) | LinkedIn 帖子创作：围绕品牌背景、主题和反馈循环打磨职业化内容 |
+| [cold-email-personalizer](./cold-email-personalizer/) | 冷邮件个性化：读取线索数据，生成结构化、可批量处理的个性化邮件 |
 
 ### 客户服务
-| Skill | 描述 | 原始模板 |
-|-------|------|---------|
-| [email-assistant](./email-assistant/) | 智能邮件助手（支持RAG知识库） | [#2852](https://n8n.io/workflows/2852) |
-| [ecommerce-support](./ecommerce-support/) | 电商客服（Playwright自动化） | [#3480](https://n8n.io/workflows/3480) |
+| Skill | 描述 |
+|-------|------|
+| [email-assistant](./email-assistant/) | 智能邮件助手：摘要、分类、知识库查询、回复草稿和审核 |
+| [ecommerce-support](./ecommerce-support/) | 电商客服：识别意图，处理订单查询、推荐、投诉和工单创建 |
 
 ### 市场调研
-| Skill | 描述 | 原始模板 |
-|-------|------|---------|
-| [storm-research-agent](./storm-research-agent/) | 中文优先的 STORM 多视角调研 Agent：证据包、矛盾地图、盲点分析、决策卡，支持中英文输出 | 自研 / Yao-style Production |
-| [social-trend-monitor](./social-trend-monitor/) | 社交趋势监控 | [#8450](https://n8n.io/workflows/8450) |
-| [influencer-evaluator](./influencer-evaluator/) | 网红评估 | [#7256](https://n8n.io/workflows/7256) |
-| [competitor-price-monitor](./competitor-price-monitor/) | 竞品价格监控 | [#8963](https://n8n.io/workflows/8963) |
-| [competitor-research](./competitor-research/) | 竞品全网调研 | [#2354](https://n8n.io/workflows/2354) |
+| Skill | 描述 |
+|-------|------|
+| [storm-research-agent](./storm-research-agent/) | 中文优先的 STORM 多视角调研：证据包、矛盾地图、盲点分析和决策卡 |
+| [social-trend-monitor](./social-trend-monitor/) | 社交趋势监控：发现多平台趋势、排序热度并生成趋势报告 |
+| [influencer-evaluator](./influencer-evaluator/) | 网红评估：解析公开账号数据，输出评分、等级和合作建议 |
+| [competitor-price-monitor](./competitor-price-monitor/) | 竞品价格监控：跟踪竞品价格变化、促销信号和异常波动 |
+| [competitor-research](./competitor-research/) | 竞品全网调研：收集竞品公开信息，输出定位、卖点、渠道和机会判断 |
 
 ### SEO与内容优化
-| Skill | 描述 | 原始模板 |
-|-------|------|---------|
-| [seo-analyzer](./seo-analyzer/) | SEO分析助手 | [#5303](https://n8n.io/workflows/5303) |
-| [geo-content-optimizer](./geo-content-optimizer/) | GEO内容优化（AI搜索友好） | [#8768](https://n8n.io/workflows/8768) |
-| [ai-readability-audit](./ai-readability-audit/) | AI可读性审计 | [#4151](https://n8n.io/workflows/4151) |
-| [youtube-video-analyzer](./youtube-video-analyzer/) | YouTube视频分析 | [#2679](https://n8n.io/workflows/2679) |
+| Skill | 描述 |
+|-------|------|
+| [seo-analyzer](./seo-analyzer/) | SEO 分析：检查页面结构、技术指标、内容质量和优化建议 |
+| [geo-content-optimizer](./geo-content-optimizer/) | GEO 内容优化：让内容更适合 AI 搜索、引用和答案生成 |
+| [ai-readability-audit](./ai-readability-audit/) | AI 可读性审计：检查内容是否易被 AI 抽取、理解和引用 |
+| [youtube-video-analyzer](./youtube-video-analyzer/) | YouTube 视频分析：提取字幕/信息，生成摘要、结构和可复用洞察 |
 
 ### 工具
 | Skill | 描述 |
@@ -65,7 +65,6 @@ cp -r <skill-name> ~/.claude/skills/
 - "检查这个网站的SEO"
 - "用 STORM 调研这个选题是否值得写"
 - "用 loopforge 把这个工作流变成可复用 loop spec 和提示词"
-- 为来实现和n8n的工作节点相同,有些skill绕路远路,建议可以依据需要修改
 
 ## 依赖的 MCP 服务
 

--- a/WORKFLOW_COMPARISON_REPORT.md
+++ b/WORKFLOW_COMPARISON_REPORT.md
@@ -1,5 +1,7 @@
 # n8n 工作流与 Claude Code Skill 对比检查报告
 
+> 历史报告：本文只覆盖最早一批 n8n 工作流转换 skill，不覆盖后续加入的自研工具类 skill，例如 `storm-research-agent`、`grok`、`claude-review`、`loopforge`。
+
 **检查时间**: 2025-12-29
 **检查人**: Claude Code
 **检查范围**: 14个转换后的技能

--- a/install.sh
+++ b/install.sh
@@ -20,6 +20,7 @@ skills=(
     "competitor-research"
     "geo-content-optimizer"
     "ai-readability-audit"
+    "loopforge"
     "grok"
 )
 
@@ -49,4 +50,5 @@ echo "  - '调研这个竞品' -> competitor-research"
 echo "  - '用 STORM 调研这个选题是否值得写' -> storm-research-agent"
 echo "  - 'GEO优化这篇文章' -> geo-content-optimizer"
 echo "  - '检查网站AI可读性' -> ai-readability-audit"
+echo "  - '用 loopforge 把这个工作流变成 loop spec 和提示词' -> loopforge"
 echo "  - '问问 grok / X 上...' -> grok（实时 X 抓取，需先装 grok-build CLI 并登录 grok.com）"

--- a/loopforge/README.md
+++ b/loopforge/README.md
@@ -1,0 +1,48 @@
+# loopforge
+
+把模糊工作流锻造成可维护、可验证、可复用的 AI-agent workflow loop。
+
+## 适合做什么
+
+- 从成功案例、聊天记录、prompt、草稿或工作历史里提炼可复用 loop。
+- 创建 `loop-spec-v1` YAML/JSON。
+- 同时输出一份给人复制使用的模块化 Loop Prompt。
+- 审查已有 loop：`Ready`、`Repair needed`、`Not actually a loop`。
+- 区分 loop、goal、SOP、checklist、cron job、一次性任务和系统动力学 feedback loop。
+
+## 不适合做什么
+
+- 查找官方 Loop Library 已发布条目。
+- 直接执行 loop。
+- 只写 `/goal` 指令。
+- 做泛泛的增长飞轮或系统反馈环分析。
+
+## 默认输出
+
+生成 loop 时默认输出两部分：
+
+```text
+## Loop Spec
+<loop-spec-v1 YAML/JSON>
+
+## Loop Prompt
+<可复制给 agent 直接运行的一份模块化提示词>
+```
+
+除非用户明确要求 machine-only output，否则不要只给 YAML。
+
+## 快速使用
+
+```text
+用 loopforge 把这个工作流变成可复用 loop spec 和提示词：
+<贴上你的流程、prompt、运行记录或成功案例>
+```
+
+## 校验
+
+```bash
+python3 loopforge/scripts/lint_loop_spec.py --self-test
+python3 loopforge/scripts/lint_loop_spec.py --profile runnable path/to/spec.yaml
+```
+
+`template` profile 允许声明过的占位符；`runnable` profile 要求可直接运行，不能有未替换占位符。

--- a/loopforge/SKILL.md
+++ b/loopforge/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: loopforge
+description: Compile, validate, repair, and package AI-agent workflow loop specs. Use to extract, forge, doctor, or package repeatable agent workflow loops, or distinguish loops from goals, SOPs, checklists, cron jobs, one-shot tasks, and systems-thinking feedback loops. Do not use for official loop search, direct execution, or pure /goal commands.
+metadata:
+  lifecycle_stage: library
+  context_budget_tier: production
+  source_inspiration: Forward Future Loop Library, qiaomu-goal-meta-skill, yao-meta-skill
+---
+
+# Loopforge
+
+Turn fuzzy workflows into reusable AI-agent workflow loop specs.
+
+## Route
+
+Choose one path:
+
+- `Extract`: convert notes, transcripts, prompts, artifacts, or history into a loop spec.
+- `Forge`: create a new loop spec from the user's intended recurring workflow.
+- `Doctor`: audit and minimally repair an existing loop spec.
+- `Package`: prepare a loop spec for reuse or publication.
+
+Do not handle:
+
+- official published loop search; send that to the official Loop Library skill or catalog
+- direct loop execution; hand off to the runtime
+- pure `/goal` writing; use a goal skill when available
+- general systems-thinking feedback-loop analysis
+
+## Intake
+
+Ask one high-leverage question by default; ask up to three only when answers materially change the spec. Default only when grounded or safe no-op. Ask for permissions, security, production writes, external messages, private data, and validation.
+
+## Required Reading
+
+- For boundary decisions, read `references/loop-vs-goal-sop-checklist.md`.
+- For spec fields, read `references/loop-spec-v1.md`.
+- For repair work, read `references/loop-doctor.md`.
+- For examples or pattern help, read `references/case-patterns.md` and `references/templates.md`.
+
+## Output Contract
+
+Return one:
+
+- a concise prompt-mode loop the user can copy
+- a full `loop-spec-v1` YAML or JSON spec, followed by a copy-ready Loop Prompt companion unless the user asks for machine-only output
+- a doctor verdict: `Ready`, `Repair needed`, or `Not actually a loop`
+- a package checklist for reuse or publication
+
+Every spec must satisfy `references/loop-spec-v1.md`: identity, trigger/exclusion, inputs, authority, state, round, `next_action_rule`, `working_signal`, `acceptance_gate`, terminal states, outputs, provenance, and optional `execution_handoff`.
+
+When outputting YAML/JSON, also finish with the module-based `Loop Prompt` from `references/templates.md`. YAML/JSON is the source; the prompt is the copy/use entry.
+
+## Validation
+
+For YAML/JSON specs, run:
+
+```bash
+python3 scripts/lint_loop_spec.py <spec-file>
+```
+
+Use `--profile template` for reusable templates with declared placeholders. Use `--profile runnable` when the loop is ready to run and placeholders must be gone.
+
+If the linter fails, fix the spec before presenting it as ready.

--- a/loopforge/THIRD_PARTY_NOTICES.md
+++ b/loopforge/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,13 @@
+# Third Party Notices
+
+This skill was informed by the public Forward Future Loop Library and local meta-skill patterns.
+
+## Forward Future Loop Library
+
+- Source: https://signals.forwardfuture.ai/loop-library/
+- Catalog: https://signals.forwardfuture.ai/loop-library/catalog.json
+- Repository: https://github.com/Forward-Future/loop-library
+- License: MIT
+- Copyright: Forward Future
+
+This package does not include a full copied catalog. If generated catalog snapshots or substantial adapted case text are added later, keep source URL, source date, source count, hash or commit metadata, and MIT attribution with the generated file.

--- a/loopforge/agents/interface.yaml
+++ b/loopforge/agents/interface.yaml
@@ -1,0 +1,24 @@
+interface:
+  display_name: "Loopforge"
+  short_description: "Compile, validate, repair, and package reusable AI-agent workflow loop specs."
+  default_prompt: "Use $loopforge to turn this workflow, prompt, transcript, or artifact into a reusable loop spec. Distinguish it from a goal, SOP, checklist, cron job, one-shot task, or systems-thinking feedback loop. For YAML/JSON specs, also include a copy-ready Loop Prompt unless I ask for machine-only output. Lint specs before marking ready."
+compatibility:
+  canonical_format: "agent-skills"
+  adapter_targets:
+    - "openai"
+    - "claude"
+    - "generic"
+  activation:
+    mode: "manual"
+    paths: []
+  execution:
+    context: "inline"
+    shell: "bash"
+  trust:
+    source_tier: "local"
+    remote_inline_execution: "forbid"
+    remote_metadata_policy: "allow-metadata-only"
+  degradation:
+    openai: "creates and repairs loop-spec-v1 workflow specs from available task context"
+    claude: "uses the same loop boundaries and spec fields with Claude-compatible prose"
+    generic: "uses the canonical loop template and asks for missing high-impact criteria"

--- a/loopforge/manifest.json
+++ b/loopforge/manifest.json
@@ -1,0 +1,21 @@
+{
+  "name": "loopforge",
+  "version": "0.1.0",
+  "owner": "local",
+  "updated_at": "2026-06-22",
+  "status": "draft",
+  "maturity_tier": "library",
+  "lifecycle_stage": "library",
+  "context_budget_tier": "production",
+  "review_cadence": "quarterly",
+  "target_platforms": [
+    "openai",
+    "claude",
+    "generic",
+    "agent-skills-compatible"
+  ],
+  "factory_components": [
+    "references",
+    "scripts"
+  ]
+}

--- a/loopforge/references/case-patterns.md
+++ b/loopforge/references/case-patterns.md
@@ -1,0 +1,22 @@
+# Case Patterns
+
+Use patterns, not copied catalog cards.
+
+## Mother Patterns
+
+1. Source-to-judgment loop: collect evidence, compare against criteria, record decision.
+2. Draft-to-review loop: draft, inspect against rubric, revise or stop.
+3. Bug investigation loop: reproduce, hypothesize, change one variable, verify.
+4. Completion-contract loop: compare claimed completion with evidence, repair gaps.
+5. Research synthesis loop: gather sources, extract claims, verify citations, synthesize.
+6. Data quality loop: inspect sample, detect issue class, patch or escalate.
+7. Design critique loop: inspect artifact, identify material issue, repair or approve.
+8. Release readiness loop: run gates, fix blockers, record status.
+9. Monitoring loop: observe signal, decide action, record or alert.
+10. Customer follow-up loop: inspect case state, choose next response, verify resolution.
+11. Prompt hardening loop: test against examples, repair failure mode, re-test.
+12. Packaging loop: validate files, notices, route quality, and installability.
+
+## Pattern Rule
+
+Do not copy a full external loop into output unless the user asks and attribution is present. Prefer a local adaptation with source URL and provenance.

--- a/loopforge/references/interview.md
+++ b/loopforge/references/interview.md
@@ -1,0 +1,17 @@
+# Interview
+
+Ask the fewest questions that change the loop.
+
+Start with one:
+
+```text
+What recurring job should this loop make an agent better at, and what evidence should change the next action?
+```
+
+Ask follow-ups only when missing:
+
+1. What can the agent read or change?
+2. What proof shows a round worked?
+3. When should it stop, ask approval, or declare no-op?
+
+Defaults are allowed only for naming, format, low-risk wording, and safe no-op behavior. Do not default permissions, production writes, external sends, private data access, or verification methods.

--- a/loopforge/references/loop-doctor.md
+++ b/loopforge/references/loop-doctor.md
@@ -1,0 +1,46 @@
+# Loop Doctor
+
+Use this for audit and repair.
+
+## Verdicts
+
+```text
+Verdict: Ready | Repair needed | Not actually a loop
+Diagnosis: up to three material findings
+Result: repaired loop or no repair needed
+```
+
+## Ready
+
+Use when the loop has:
+
+- feedback-driven next action
+- concrete verification
+- authority boundaries
+- terminal states
+- preserved state or records
+
+Do not rewrite style-only issues.
+
+## Repair Needed
+
+Use when the loop is basically valid but missing a material piece:
+
+- weak `next_action_rule`
+- vague verification
+- missing approval boundary
+- missing terminal state
+- no state record
+- unclear trigger or exclusion
+
+Repair the smallest part that makes it valid.
+
+## Not Actually A Loop
+
+Use when:
+
+- feedback cannot change the next action
+- it is only a fixed SOP, checklist, template, or one-off command
+- it is a general systems feedback-loop analysis, not an AI-agent workflow loop
+
+Return the correct alternative: goal, SOP, checklist, template, or systems analysis.

--- a/loopforge/references/loop-spec-v1.md
+++ b/loopforge/references/loop-spec-v1.md
@@ -1,0 +1,72 @@
+# Loop Spec v1
+
+Use YAML or JSON. YAML is easier for humans; JSON is better for automation.
+
+When producing a spec for a user, include a copy-ready Loop Prompt after the YAML/JSON unless the user asks for machine-only output.
+
+## Required Fields
+
+```yaml
+spec_version: 1
+kind: agent-workflow-loop
+status: draft | provisional | tested | published
+name:
+purpose:
+use_when:
+do_not_use_when:
+parameters: {}
+inputs: []
+authority:
+  may_read: []
+  may_write: []
+  must_ask_before: []
+state:
+  stores: []
+  update_rule:
+round:
+  observe:
+  choose:
+  act:
+  verify:
+  record:
+next_action_rule:
+working_signal:
+acceptance_gate:
+terminal_states:
+  success:
+  clean_noop:
+  blocked:
+  approval_required:
+  exhausted:
+  stagnated:
+outputs: []
+provenance:
+  sources: []
+  generated_at:
+execution_handoff:
+  enabled: false
+  target:
+  notes:
+```
+
+## Field Rules
+
+- `use_when` describes when feedback can change the next action.
+- `do_not_use_when` names near-neighbor tasks that should route elsewhere.
+- `authority.must_ask_before` covers destructive writes, production, external messages, paid actions, private data, and account changes.
+- `round.observe` names the evidence source.
+- `round.choose` explains how evidence selects the next action.
+- `round.verify` names concrete proof: command, log, file, screenshot, API response, human approval, or external read-back.
+- `round.record` preserves enough state for the next round.
+- `next_action_rule` is the core of the loop. If it is missing, this is probably an SOP.
+- `working_signal` is the leading indicator that the current attempt is improving.
+- `acceptance_gate` is the condition before declaring success.
+- `terminal_states` must include success, clean no-op, blocked, approval required, exhausted, and stagnated.
+- `execution_handoff` is optional and runtime-neutral. Do not hard-code `/goal`, cron, GitHub Actions, or any private runtime as the only target.
+
+## Status
+
+- `draft`: useful but incomplete
+- `provisional`: internally coherent but not field-tested
+- `tested`: verified on at least one realistic case
+- `published`: ready for external reuse, with provenance and notices

--- a/loopforge/references/loop-vs-goal-sop-checklist.md
+++ b/loopforge/references/loop-vs-goal-sop-checklist.md
@@ -1,0 +1,67 @@
+# Loop vs Goal vs SOP vs Checklist
+
+Use this file when routing is ambiguous.
+
+## Loop
+
+An AI-agent workflow loop is a reusable mechanism where evidence from each round can change the next action.
+
+It must have:
+
+- a trigger
+- facts or inputs to observe
+- a next-action rule
+- verification evidence
+- state or records that survive the round
+- terminal states
+- authority boundaries
+
+Good loop test:
+
+```text
+If the latest evidence cannot change what the agent does next, this is not a loop.
+```
+
+## Goal
+
+A goal is one execution contract for a specific outcome.
+
+Use a goal when the user mainly needs:
+
+- one concrete result
+- success criteria
+- constraints
+- iteration policy for this task
+- stop and pause conditions
+
+A loop may include `execution_handoff`, but the loop itself is not the execution container.
+
+## SOP
+
+An SOP is a fixed sequence. It can repeat, but feedback does not decide the next action.
+
+Use SOP when the task is:
+
+- follow these steps every time
+- run this checklist on schedule
+- no branch based on observed evidence
+
+## Checklist
+
+A checklist confirms coverage. It asks whether items were covered, not what the agent should do next.
+
+Use checklist when the output is only:
+
+- pass/fail coverage
+- missing-item list
+- static review criteria
+
+## One-Shot Work
+
+One-shot work can still be a loop instance when each round's evidence changes the next move, such as debugging or investigation.
+
+Do not reject a loop only because it may run once. Reject it when there is no feedback-driven next action.
+
+## Out Of Scope
+
+General systems-thinking feedback loops, growth flywheels, reinforcing loops, balancing loops, and causal-loop diagrams are not Loopforge's job unless the user asks to convert them into an AI-agent workflow loop.

--- a/loopforge/references/templates.md
+++ b/loopforge/references/templates.md
@@ -1,0 +1,100 @@
+# Templates
+
+## Prompt Mode
+
+```text
+Loop: <name>
+Use when: <trigger>
+Do not use when: <exclusions>
+Inputs: <facts or files>
+Round:
+1. Observe <evidence>.
+2. Choose <next action based on evidence>.
+3. Act <one bounded change>.
+4. Verify <proof>.
+5. Record <state for next round>.
+Continue when: <signal>
+Stop when: <terminal states>
+Ask before: <authority boundary>
+Outputs: <artifacts>
+```
+
+## Spec Plus Prompt Output
+
+Use this when creating a YAML/JSON loop spec. Output both parts unless the user asks for machine-only output.
+
+```text
+## Loop Spec
+
+<YAML or JSON loop-spec-v1>
+
+## Loop Prompt
+
+You are running this AI-agent workflow loop: <name>.
+
+Module 1: Use When
+<use_when>
+
+Module 2: Do Not Use When
+<do_not_use_when>
+
+Module 3: Inputs
+<inputs and required facts>
+
+Module 4: Authority
+You may read: <may_read>
+You may write: <may_write>
+Ask before: <must_ask_before>
+
+Module 5: One Round
+1. Observe: <round.observe>
+2. Choose: <round.choose>
+3. Act: <round.act>
+4. Verify: <round.verify>
+5. Record: <round.record>
+
+Module 6: Next Action Rule
+<next_action_rule>
+
+Module 7: Working Signal
+<working_signal>
+
+Module 8: Acceptance Gate
+<acceptance_gate>
+
+Module 9: Stop States
+Success: <terminal_states.success>
+Clean no-op: <terminal_states.clean_noop>
+Blocked: <terminal_states.blocked>
+Approval required: <terminal_states.approval_required>
+Exhausted: <terminal_states.exhausted>
+Stagnated: <terminal_states.stagnated>
+
+Module 10: Outputs
+<outputs>
+
+Now run one bounded round. First restate the user's goal and endpoint, then execute only the next valid action.
+```
+
+## Doctor Output
+
+```text
+Verdict: Ready | Repair needed | Not actually a loop
+Diagnosis:
+- <finding 1>
+- <finding 2>
+- <finding 3>
+Result:
+<minimal repaired loop or correct alternative>
+```
+
+## Package Checklist
+
+```text
+- SKILL.md has route, exclusions, output contract, and required reading.
+- references/ holds long guidance.
+- scripts/ holds deterministic lint or render logic.
+- THIRD_PARTY_NOTICES.md exists when external sources influenced packaged examples.
+- No private paths, accounts, tokens, internal domains, or project-specific rules.
+- A runnable lint or self-check passes.
+```

--- a/loopforge/schemas/loop-spec-v1.schema.json
+++ b/loopforge/schemas/loop-spec-v1.schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Loop Spec v1",
+  "type": "object",
+  "required": [
+    "spec_version",
+    "kind",
+    "status",
+    "name",
+    "purpose",
+    "use_when",
+    "do_not_use_when",
+    "inputs",
+    "authority",
+    "state",
+    "round",
+    "next_action_rule",
+    "working_signal",
+    "acceptance_gate",
+    "terminal_states",
+    "outputs",
+    "provenance"
+  ],
+  "properties": {
+    "spec_version": { "const": 1 },
+    "kind": { "const": "agent-workflow-loop" },
+    "status": { "enum": ["draft", "provisional", "tested", "published"] },
+    "round": {
+      "type": "object",
+      "required": ["observe", "choose", "act", "verify", "record"]
+    },
+    "terminal_states": {
+      "type": "object",
+      "required": ["success", "clean_noop", "blocked", "approval_required", "exhausted", "stagnated"]
+    }
+  }
+}

--- a/loopforge/scripts/lint_loop_spec.py
+++ b/loopforge/scripts/lint_loop_spec.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""Lightweight Loop Spec v1 linter.
+
+This is intentionally text-first: it catches missing contract fields without
+adding a YAML dependency.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+
+REQUIRED_FIELDS = [
+    "spec_version",
+    "kind",
+    "status",
+    "name",
+    "purpose",
+    "use_when",
+    "do_not_use_when",
+    "inputs",
+    "authority",
+    "state",
+    "round",
+    "next_action_rule",
+    "working_signal",
+    "acceptance_gate",
+    "terminal_states",
+    "outputs",
+    "provenance",
+]
+
+ROUND_FIELDS = ["observe", "choose", "act", "verify", "record"]
+TERMINAL_FIELDS = ["success", "clean_noop", "blocked", "approval_required", "exhausted", "stagnated"]
+
+PLACEHOLDERS = [
+    r"\bTODO\b",
+    r"\bTBD\b",
+    r"<[^>\n]+>",
+    r"\[[^\]\n]+\]",
+    r"待定",
+    r"待补充",
+]
+
+VAGUE = [
+    r"keep trying",
+    r"until satisfied",
+    r"until it feels good",
+    r"make sure it works",
+    r"as needed",
+    r"看情况",
+    r"直到满意",
+    r"感觉可以",
+]
+
+PRIVATE_LEAKS = [
+    r"/Users/[A-Za-z0-9._-]+",
+    r"C:\\Users\\",
+    r"/home/[A-Za-z0-9._-]+",
+    r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}",
+    r"\b(api[_-]?key|token|secret|password)\b\s*[:=]",
+    r"\binternal\b.*\bdomain\b",
+]
+
+
+def has_field(text: str, field: str) -> bool:
+    return bool(re.search(rf"(?m)^\s*{re.escape(field)}\s*:", text))
+
+
+def load_json_if_possible(path: Path, text: str) -> dict | None:
+    if path.suffix.lower() != ".json":
+        return None
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def lint_text(text: str, source: str, profile: str) -> list[dict[str, str]]:
+    findings: list[dict[str, str]] = []
+
+    def error(message: str) -> None:
+        findings.append({"level": "error", "source": source, "message": message})
+
+    def warning(message: str) -> None:
+        findings.append({"level": "warning", "source": source, "message": message})
+
+    for field in REQUIRED_FIELDS:
+        if not has_field(text, field):
+            error(f"missing required field `{field}`")
+
+    for field in ROUND_FIELDS:
+        if not has_field(text, field):
+            error(f"missing round field `{field}`")
+
+    for field in TERMINAL_FIELDS:
+        if not has_field(text, field):
+            error(f"missing terminal state `{field}`")
+
+    if not re.search(r"spec_version\s*:\s*1\b", text):
+        error("`spec_version` must be 1")
+
+    if not re.search(r"kind\s*:\s*agent-workflow-loop\b", text):
+        error("`kind` must be agent-workflow-loop")
+
+    if not re.search(r"status\s*:\s*(draft|provisional|tested|published)\b", text):
+        error("`status` must be draft, provisional, tested, or published")
+
+    for pattern in VAGUE:
+        if re.search(pattern, text, re.IGNORECASE):
+            error(f"dangerously vague instruction matched `{pattern}`")
+
+    for pattern in PRIVATE_LEAKS:
+        if re.search(pattern, text, re.IGNORECASE):
+            error(f"possible private leak matched `{pattern}`")
+
+    if re.search(r"\b(must|required)\b.{0,40}\bAskUserQuestion\b", text, re.IGNORECASE):
+        error("runtime-specific AskUserQuestion cannot be mandatory")
+
+    if re.search(r"Loop Library|Forward Future|catalog\.json", text, re.IGNORECASE):
+        if not re.search(r"https?://", text):
+            warning("external Loop Library reference should include a source URL")
+
+    if profile == "runnable":
+        for pattern in PLACEHOLDERS:
+            if re.search(pattern, text, re.IGNORECASE):
+                error(f"unresolved placeholder matched `{pattern}`")
+    else:
+        undeclared = [
+            pattern for pattern in PLACEHOLDERS
+            if re.search(pattern, text, re.IGNORECASE) and "parameters:" not in text
+        ]
+        if undeclared:
+            warning("template placeholders found but no `parameters` field declares them")
+
+    return findings
+
+
+def lint_file(path: Path, profile: str) -> list[dict[str, str]]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return [{"level": "error", "source": str(path), "message": f"cannot read file: {exc}"}]
+
+    data = load_json_if_possible(path, text)
+    if data is not None:
+        text = "\n".join(f"{key}:" for key in data.keys()) + "\n" + text
+
+    return lint_text(text, str(path), profile)
+
+
+def self_test() -> int:
+    good = """
+spec_version: 1
+kind: agent-workflow-loop
+status: tested
+name: Source proof loop
+purpose: Verify source-backed claims.
+use_when: Evidence changes the next action.
+do_not_use_when: The user only needs a static checklist.
+parameters: {}
+inputs: []
+authority:
+  may_read: []
+  may_write: []
+  must_ask_before: []
+state:
+  stores: []
+  update_rule: Record source and decision.
+round:
+  observe: Read the source.
+  choose: Continue, revise, stop, or escalate based on evidence.
+  act: Change one claim.
+  verify: Re-read source and compare.
+  record: Save source URL and decision.
+next_action_rule: If proof is weak, gather another source; if contradicted, revise; if proven, stop.
+working_signal: More claims have direct evidence.
+acceptance_gate: All key claims cite real sources.
+terminal_states:
+  success: Evidence passes.
+  clean_noop: No claims need changes.
+  blocked: Source unavailable.
+  approval_required: Needs private source.
+  exhausted: Round cap reached.
+  stagnated: No improvement after two rounds.
+outputs: []
+provenance:
+  sources: []
+  generated_at: 2026-06-22
+"""
+    bad = "name: Bad\nround:\n  act: keep trying until satisfied\n"
+    if lint_text(good, "good", "runnable"):
+        print("self-test failed: good spec produced findings", file=sys.stderr)
+        return 1
+    if not any(item["level"] == "error" for item in lint_text(bad, "bad", "runnable")):
+        print("self-test failed: bad spec produced no errors", file=sys.stderr)
+        return 1
+    print("Loop spec lint self-test passed.")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Lint Loop Spec v1 files.")
+    parser.add_argument("files", nargs="*")
+    parser.add_argument("--profile", choices=["template", "runnable"], default="runnable")
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args(argv[1:])
+
+    if args.self_test:
+        return self_test()
+
+    if not args.files:
+        parser.error("provide at least one spec file or --self-test")
+
+    findings: list[dict[str, str]] = []
+    for raw in args.files:
+        findings.extend(lint_file(Path(raw), args.profile))
+
+    if args.format == "json":
+        print(json.dumps({"findings": findings}, indent=2, ensure_ascii=False))
+    else:
+        for item in findings:
+            print(f"{item['level']}: {item['source']}: {item['message']}", file=sys.stderr)
+        if not findings:
+            print("Loop spec lint passed.")
+
+    return 1 if any(item["level"] == "error" for item in findings) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))


### PR DESCRIPTION
## 摘要
- 新增 `loopforge` 技能，用来创建、修复和打包 AI Agent 工作流循环。
- 增加「Loop Spec + Loop Prompt」双输出，让使用者既拿到机器可校验的 YAML/JSON，也拿到可直接复制执行的提示词。
- 更新 README、安装脚本和历史报告说明，仓库公开描述改为按技能能力介绍。

## 验证
- `python3 loopforge/scripts/lint_loop_spec.py --self-test`
- `python3 /Users/sky/.cc-switch/skills/yao-meta-skill/scripts/validate_skill.py loopforge`
- `python3 /Users/sky/.cc-switch/skills/yao-meta-skill/scripts/lint_skill.py loopforge`
- `python3 /Users/sky/.cc-switch/skills/yao-meta-skill/scripts/resource_boundary_check.py loopforge`
- `bash -n install.sh`
- `python3 -m json.tool loopforge/manifest.json`
- `python3 -m json.tool loopforge/schemas/loop-spec-v1.schema.json`
- 私密信息扫描：未发现泄露。
